### PR TITLE
Spring boot 3.0 compatibility fixes #320

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ version = '4.4.6-SNAPSHOT'
 // Properties
 
 ext {
-    baselineJavaVersion = JavaVersion.VERSION_17
+    baselineJavaVersion = JavaVersion.VERSION_1_8
     sourceEncoding = "UTF-8"
 
     // Set up different sub-project lists for individual configuration

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ version = '4.4.6-SNAPSHOT'
 // Properties
 
 ext {
-    baselineJavaVersion = JavaVersion.VERSION_1_8
+    baselineJavaVersion = JavaVersion.VERSION_17
     sourceEncoding = "UTF-8"
 
     // Set up different sub-project lists for individual configuration

--- a/buildSrc/src/main/java/org/jodconverter/Deps.java
+++ b/buildSrc/src/main/java/org/jodconverter/Deps.java
@@ -18,7 +18,7 @@ public class Deps {
 
   // Spring Boot libraries
   // Latest version -> https://mvnrepository.com/artifact/org.springframework.boot/spring-boot
-  public static final String springBootVersion = "3.0.1";
+  public static final String springBootVersion = "2.7.7";
   public static final String springBootDependencies =
       "org.springframework.boot:spring-boot-dependencies:" + springBootVersion;
   public static final String springBootStarter = "org.springframework.boot:spring-boot-starter";

--- a/buildSrc/src/main/java/org/jodconverter/Deps.java
+++ b/buildSrc/src/main/java/org/jodconverter/Deps.java
@@ -18,7 +18,7 @@ public class Deps {
 
   // Spring Boot libraries
   // Latest version -> https://mvnrepository.com/artifact/org.springframework.boot/spring-boot
-  public static final String springBootVersion = "2.7.6";
+  public static final String springBootVersion = "3.0.1";
   public static final String springBootDependencies =
       "org.springframework.boot:spring-boot-dependencies:" + springBootVersion;
   public static final String springBootStarter = "org.springframework.boot:spring-boot-starter";
@@ -42,6 +42,8 @@ public class Deps {
   public static final String springCore = "org.springframework:spring-core";
   public static final String springContext = "org.springframework:spring-context";
   public static final String springTest = "org.springframework:spring-test";
+
+  public static final String javaxAnnotations = "javax.annotation:javax.annotation-api:1.3.2";
 
   // HTTP Components libraries
   public static final String httpcomponentsHttpcore = "org.apache.httpcomponents:httpcore";

--- a/jodconverter-spring-boot-starter/build.gradle
+++ b/jodconverter-spring-boot-starter/build.gradle
@@ -15,4 +15,5 @@ dependencies {
 
     testImplementation Deps.wiremock
     testImplementation Deps.springBootStarterTest
+    testImplementation Deps.javaxAnnotations
 }

--- a/jodconverter-spring-boot-starter/src/main/java/org/jodconverter/boot/autoconfigure/JodConverterLocalAutoConfiguration.java
+++ b/jodconverter-spring-boot-starter/src/main/java/org/jodconverter/boot/autoconfigure/JodConverterLocalAutoConfiguration.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import com.sun.star.document.UpdateDocMode;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -48,7 +49,7 @@ import org.jodconverter.local.office.LocalOfficeUtils;
 import org.jodconverter.local.process.ProcessManager;
 
 /** {@link EnableAutoConfiguration Auto-configuration} for JodConverter local module. */
-@Configuration
+@AutoConfiguration
 @ConditionalOnClass(LocalConverter.class)
 @ConditionalOnProperty(prefix = "jodconverter.local", name = "enabled", havingValue = "true")
 @EnableConfigurationProperties(JodConverterLocalProperties.class)

--- a/jodconverter-spring-boot-starter/src/main/java/org/jodconverter/boot/autoconfigure/JodConverterLocalAutoConfiguration.java
+++ b/jodconverter-spring-boot-starter/src/main/java/org/jodconverter/boot/autoconfigure/JodConverterLocalAutoConfiguration.java
@@ -34,7 +34,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
 
 import org.jodconverter.core.DocumentConverter;

--- a/jodconverter-spring-boot-starter/src/main/java/org/jodconverter/boot/autoconfigure/JodConverterLocalProperties.java
+++ b/jodconverter-spring-boot-starter/src/main/java/org/jodconverter/boot/autoconfigure/JodConverterLocalProperties.java
@@ -31,9 +31,14 @@ import org.jodconverter.local.LocalConverter;
 import org.jodconverter.local.office.ExistingProcessAction;
 import org.jodconverter.local.office.LocalOfficeManager;
 import org.jodconverter.local.task.LoadDocumentMode;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+
+import static org.jodconverter.core.office.AbstractOfficeManagerPool.DEFAULT_TASK_EXECUTION_TIMEOUT;
+import static org.jodconverter.core.office.AbstractOfficeManagerPool.DEFAULT_TASK_QUEUE_TIMEOUT;
 
 /** Configuration class for JODConverter. */
 @ConfigurationProperties("jodconverter.local")
+@ConfigurationPropertiesScan
 public class JodConverterLocalProperties {
 
   /** Enable JODConverter, which means that office instances will be launched. */
@@ -129,13 +134,13 @@ public class JodConverterLocalProperties {
    * Maximum living time of a task in the conversion queue. The task will be removed from the queue
    * if the waiting time is longer than this timeout.
    */
-  private long taskQueueTimeout = LocalOfficeManager.DEFAULT_TASK_QUEUE_TIMEOUT;
+  private long taskQueueTimeout = DEFAULT_TASK_QUEUE_TIMEOUT;
 
   /**
    * Maximum time allowed to process a task. If the processing time of a task is longer than this
    * timeout, this task will be aborted and the next task is processed.
    */
-  private long taskExecutionTimeout = LocalOfficeManager.DEFAULT_TASK_EXECUTION_TIMEOUT;
+  private long taskExecutionTimeout = DEFAULT_TASK_EXECUTION_TIMEOUT;
 
   /** Maximum number of tasks an office process can execute before restarting. */
   private int maxTasksPerProcess = LocalOfficeManager.DEFAULT_MAX_TASKS_PER_PROCESS;

--- a/jodconverter-spring-boot-starter/src/main/java/org/jodconverter/boot/autoconfigure/JodConverterLocalProperties.java
+++ b/jodconverter-spring-boot-starter/src/main/java/org/jodconverter/boot/autoconfigure/JodConverterLocalProperties.java
@@ -25,16 +25,14 @@ import java.util.Map;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 import org.jodconverter.core.document.DocumentFormatProperties;
+import org.jodconverter.core.office.AbstractOfficeManagerPool;
 import org.jodconverter.local.LocalConverter;
 import org.jodconverter.local.office.ExistingProcessAction;
 import org.jodconverter.local.office.LocalOfficeManager;
 import org.jodconverter.local.task.LoadDocumentMode;
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-
-import static org.jodconverter.core.office.AbstractOfficeManagerPool.DEFAULT_TASK_EXECUTION_TIMEOUT;
-import static org.jodconverter.core.office.AbstractOfficeManagerPool.DEFAULT_TASK_QUEUE_TIMEOUT;
 
 /** Configuration class for JODConverter. */
 @ConfigurationProperties("jodconverter.local")
@@ -134,13 +132,13 @@ public class JodConverterLocalProperties {
    * Maximum living time of a task in the conversion queue. The task will be removed from the queue
    * if the waiting time is longer than this timeout.
    */
-  private long taskQueueTimeout = DEFAULT_TASK_QUEUE_TIMEOUT;
+  private long taskQueueTimeout = AbstractOfficeManagerPool.DEFAULT_TASK_QUEUE_TIMEOUT;
 
   /**
    * Maximum time allowed to process a task. If the processing time of a task is longer than this
    * timeout, this task will be aborted and the next task is processed.
    */
-  private long taskExecutionTimeout = DEFAULT_TASK_EXECUTION_TIMEOUT;
+  private long taskExecutionTimeout = AbstractOfficeManagerPool.DEFAULT_TASK_EXECUTION_TIMEOUT;
 
   /** Maximum number of tasks an office process can execute before restarting. */
   private int maxTasksPerProcess = LocalOfficeManager.DEFAULT_MAX_TASKS_PER_PROCESS;

--- a/jodconverter-spring-boot-starter/src/main/java/org/jodconverter/boot/autoconfigure/JodConverterRemoteAutoConfiguration.java
+++ b/jodconverter-spring-boot-starter/src/main/java/org/jodconverter/boot/autoconfigure/JodConverterRemoteAutoConfiguration.java
@@ -29,7 +29,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 import org.jodconverter.core.DocumentConverter;
 import org.jodconverter.core.office.OfficeManager;
@@ -51,7 +50,8 @@ public class JodConverterRemoteAutoConfiguration {
    *
    * @param properties The remote properties.
    */
-  public JodConverterRemoteAutoConfiguration(final @NonNull JodConverterRemoteProperties properties) {
+  public JodConverterRemoteAutoConfiguration(
+      final @NonNull JodConverterRemoteProperties properties) {
     this.properties = properties;
   }
 

--- a/jodconverter-spring-boot-starter/src/main/java/org/jodconverter/boot/autoconfigure/JodConverterRemoteAutoConfiguration.java
+++ b/jodconverter-spring-boot-starter/src/main/java/org/jodconverter/boot/autoconfigure/JodConverterRemoteAutoConfiguration.java
@@ -21,6 +21,7 @@
 package org.jodconverter.boot.autoconfigure;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -37,7 +38,7 @@ import org.jodconverter.remote.RemoteConverter;
 import org.jodconverter.remote.office.RemoteOfficeManager;
 
 /** {@link EnableAutoConfiguration Auto-configuration} for JodConverter remote module. */
-@Configuration
+@AutoConfiguration
 @ConditionalOnClass(RemoteConverter.class)
 @ConditionalOnProperty(prefix = "jodconverter.remote", name = "enabled", havingValue = "true")
 @EnableConfigurationProperties(JodConverterRemoteProperties.class)

--- a/jodconverter-spring-boot-starter/src/main/java/org/jodconverter/boot/autoconfigure/JodConverterRemoteAutoConfiguration.java
+++ b/jodconverter-spring-boot-starter/src/main/java/org/jodconverter/boot/autoconfigure/JodConverterRemoteAutoConfiguration.java
@@ -51,8 +51,7 @@ public class JodConverterRemoteAutoConfiguration {
    *
    * @param properties The remote properties.
    */
-  public JodConverterRemoteAutoConfiguration(
-      final @NonNull JodConverterRemoteProperties properties) {
+  public JodConverterRemoteAutoConfiguration(final @NonNull JodConverterRemoteProperties properties) {
     this.properties = properties;
   }
 

--- a/jodconverter-spring-boot-starter/src/main/java/org/jodconverter/boot/autoconfigure/JodConverterRemoteProperties.java
+++ b/jodconverter-spring-boot-starter/src/main/java/org/jodconverter/boot/autoconfigure/JodConverterRemoteProperties.java
@@ -22,7 +22,9 @@ package org.jodconverter.boot.autoconfigure;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.springframework.boot.context.properties.*;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 import org.jodconverter.remote.ssl.SslConfig;
 

--- a/jodconverter-spring-boot-starter/src/main/java/org/jodconverter/boot/autoconfigure/JodConverterRemoteProperties.java
+++ b/jodconverter-spring-boot-starter/src/main/java/org/jodconverter/boot/autoconfigure/JodConverterRemoteProperties.java
@@ -22,13 +22,13 @@ package org.jodconverter.boot.autoconfigure;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.boot.context.properties.*;
 
 import org.jodconverter.remote.ssl.SslConfig;
 
 /** Configuration class for JODConverter Remote. */
 @ConfigurationProperties("jodconverter.remote")
+@ConfigurationPropertiesScan
 @SuppressWarnings({
   "PMD.ArrayIsStoredDirectly",
   "PMD.ExcessivePublicCount",

--- a/jodconverter-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/jodconverter-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,0 @@
-# Auto Configure
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.jodconverter.boot.autoconfigure.JodConverterLocalAutoConfiguration,\
-org.jodconverter.boot.autoconfigure.JodConverterRemoteAutoConfiguration

--- a/jodconverter-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/jodconverter-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+org.jodconverter.boot.autoconfigure.JodConverterLocalAutoConfiguration
+org.jodconverter.boot.autoconfigure.JodConverterRemoteAutoConfiguration

--- a/jodconverter-spring/build.gradle
+++ b/jodconverter-spring/build.gradle
@@ -2,10 +2,6 @@ import org.jodconverter.Deps
 
 ext.moduleName = 'JODConverter Spring'
 ext.moduleDescription = 'Spring integration module of the Java OpenDocument Converter (JODConverter) project.'
-
-sourceCompatibility = 17
-targetCompatibility = 17
-
 dependencies {
     implementation project(":jodconverter-local")
 

--- a/jodconverter-spring/build.gradle
+++ b/jodconverter-spring/build.gradle
@@ -3,12 +3,16 @@ import org.jodconverter.Deps
 ext.moduleName = 'JODConverter Spring'
 ext.moduleDescription = 'Spring integration module of the Java OpenDocument Converter (JODConverter) project.'
 
+sourceCompatibility = 17
+targetCompatibility = 17
+
 dependencies {
     implementation project(":jodconverter-local")
 
     implementation Deps.slf4jLog4j
     implementation Deps.springCore
     implementation Deps.springContext
+    implementation Deps.javaxAnnotations
 
     testImplementation Deps.springTest
     testImplementation Deps.slf4jLog4j


### PR DESCRIPTION
Ensure compatibility with spring boot 3.0

- Fix AutoConfiguration implementation - migrate from the no longer working `spring.factories`
- fix properties
- add javax.annotations so we are ready to support java8+ 