### PR TITLE
Add support for additional HTML extension alias

### DIFF
--- a/jodconverter-core/src/main/resources/document-formats.json
+++ b/jodconverter-core/src/main/resources/document-formats.json
@@ -86,7 +86,8 @@
   {
     "name": "HTML",
     "extensions": [
-      "html"
+      "html",
+      "htm"
     ],
     "mediaType": "text/html",
     "inputFamily": "WEB",

--- a/jodconverter-local/src/integTest/java/org/jodconverter/local/DocumentConverterFunctionalITest.java
+++ b/jodconverter-local/src/integTest/java/org/jodconverter/local/DocumentConverterFunctionalITest.java
@@ -66,6 +66,16 @@ class DocumentConverterFunctionalITest {
   }
 
   @Test
+  void testHtmConversion(final @TempDir File testFolder, final DocumentConverter converter) {
+
+    final File source = documentFile("test.htm");
+    final File target = new File(testFolder, "test.pdf");
+
+    // Convert the file to PDF
+    converter.convert(source).to(target);
+  }
+
+  @Test
   void testCustomDocumentFormats(
       final @TempDir File testFolder, final DocumentConverter converter) {
 

--- a/jodconverter-local/src/integTest/resources/documents/test.htm
+++ b/jodconverter-local/src/integTest/resources/documents/test.htm
@@ -1,0 +1,28 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<HTML>
+<HEAD>
+    <META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=utf-8">
+    <TITLE></TITLE>
+    <META NAME="GENERATOR" CONTENT="OpenOffice.org 2.4  (Linux)">
+    <META NAME="AUTHOR" CONTENT="Mirko Nasato">
+    <META NAME="CREATED" CONTENT="20080712;15031700">
+    <META NAME="CHANGEDBY" CONTENT="Mirko Nasato">
+    <META NAME="CHANGED" CONTENT="20080712;15034700">
+    <STYLE TYPE="text/css">
+	<!--
+		@page { margin: 2cm }
+		P { margin-bottom: 0.21cm }
+		P.western { so-language: en-GB }
+	-->
+
+
+
+
+
+
+    </STYLE>
+</HEAD>
+<BODY LANG="en-GB" DIR="LTR">
+<P CLASS="western" STYLE="margin-bottom: 0cm">Test document</P>
+</BODY>
+</HTML>


### PR DESCRIPTION
There is no difference between `htm` and `html`. `htm` exists from a historic file name extension on old versions of Microsoft operating systems (FAT file system based). As a result the additional extension can be added with to the extensions alias without additional work.