### PR TITLE
add support for websocket urps available >= LibreOffice 24.2

### DIFF
--- a/jodconverter-local/src/main/java/org/jodconverter/local/office/ExternalOfficeManager.java
+++ b/jodconverter-local/src/main/java/org/jodconverter/local/office/ExternalOfficeManager.java
@@ -141,6 +141,7 @@ public final class ExternalOfficeManager
     private List<String> pipeNames;
     private String hostName = DEFAULT_HOSTNAME;
     private List<Integer> portNumbers;
+    private List<String> websocketUrls;
     private Boolean connectOnStart = DEFAULT_CONNECT_ON_START;
     private long connectTimeout = DEFAULT_CONNECT_TIMEOUT;
     private Long connectRetryInterval = DEFAULT_CONNECT_RETRY_INTERVAL;
@@ -161,7 +162,7 @@ public final class ExternalOfficeManager
       // Build the manager
       final ExternalOfficeManager manager =
           new ExternalOfficeManager(
-              LocalOfficeUtils.buildOfficeUrls(hostName, portNumbers, pipeNames),
+              LocalOfficeUtils.buildOfficeUrls(hostName, portNumbers, pipeNames, websocketUrls),
               workingDir,
               connectOnStart,
               connectTimeout,
@@ -213,6 +214,21 @@ public final class ExternalOfficeManager
 
       if (portNumbers != null && portNumbers.length != 0) {
         this.portNumbers = Arrays.stream(portNumbers).boxed().collect(Collectors.toList());
+      }
+      return this;
+    }
+
+    /**
+     * Specifies the websocket urls that will be used to communicate with office. An instance of
+     * office will be launched for each websocket url.
+     *
+     * @param websocketUrls The websocket urls to use.
+     * @return This builder instance.
+     */
+    public @NonNull Builder websocketUrls(final @Nullable String... websocketUrls) {
+
+      if (websocketUrls != null && websocketUrls.length != 0) {
+        this.websocketUrls = Arrays.asList(websocketUrls);
       }
       return this;
     }

--- a/jodconverter-local/src/main/java/org/jodconverter/local/office/LocalOfficeManager.java
+++ b/jodconverter-local/src/main/java/org/jodconverter/local/office/LocalOfficeManager.java
@@ -206,7 +206,7 @@ public final class LocalOfficeManager
       // Build the office URLs
       final LocalOfficeManager manager =
           new LocalOfficeManager(
-              LocalOfficeUtils.buildOfficeUrls(hostName, portNumbers, pipeNames),
+              LocalOfficeUtils.buildOfficeUrls(hostName, portNumbers, pipeNames, null),
               officeHome,
               workingDir,
               processManager,

--- a/jodconverter-local/src/main/java/org/jodconverter/local/office/LocalOfficeUtils.java
+++ b/jodconverter-local/src/main/java/org/jodconverter/local/office/LocalOfficeUtils.java
@@ -190,7 +190,7 @@ public final class LocalOfficeUtils {
   public static @NonNull List<@NonNull OfficeUrl> buildOfficeUrls(
       final @Nullable List<@NonNull Integer> portNumbers,
       final @Nullable List<@NonNull String> pipeNames) {
-    return buildOfficeUrls(null, portNumbers, pipeNames);
+    return buildOfficeUrls(null, portNumbers, pipeNames, null);
   }
 
   /**
@@ -199,17 +199,20 @@ public final class LocalOfficeUtils {
    * @param host The host to which open ports belong, may be null.
    * @param portNumbers The port numbers from which office URLs will be created, may be null.
    * @param pipeNames The pipe names from which office URLs will be created, may be null.
+   * @param websocketUrls The websocket urls from which office URLs will be created, may be null.
    * @return an array of office URL. If both arguments are null, then an array is returned with a
    *     single office URL, using the default port number 2002.
    */
   public static @NonNull List<@NonNull OfficeUrl> buildOfficeUrls(
       final @Nullable String host,
       final @Nullable List<@NonNull Integer> portNumbers,
-      final @Nullable List<@NonNull String> pipeNames) {
+      final @Nullable List<@NonNull String> pipeNames,
+      final @Nullable List<@NonNull String> websocketUrls) {
 
-    // Assign default value if no pipe names or port numbers have been specified.
+    // Assign default value if no pipe names, port numbers or websocketUrls have been specified.
     if ((portNumbers == null || portNumbers.isEmpty())
-        && (pipeNames == null || pipeNames.isEmpty())) {
+        && (pipeNames == null || pipeNames.isEmpty())
+        && (websocketUrls == null || websocketUrls.isEmpty())) {
       return Collections.singletonList(new OfficeUrl(host, DEFAULT_PORT));
     }
 
@@ -220,6 +223,9 @@ public final class LocalOfficeUtils {
     }
     if (pipeNames != null) {
       pipeNames.stream().map(OfficeUrl::new).forEach(officeUrls::add);
+    }
+    if (websocketUrls != null) {
+      websocketUrls.stream().map(OfficeUrl::createForWebsocket).forEach(officeUrls::add);
     }
     return officeUrls;
   }

--- a/jodconverter-local/src/main/java/org/jodconverter/local/office/OfficeUrl.java
+++ b/jodconverter-local/src/main/java/org/jodconverter/local/office/OfficeUrl.java
@@ -97,6 +97,20 @@ class OfficeUrl {
   }
 
   /**
+   * Creates an UnoUrl for the specified websocket url.
+   *
+   * @param url The url.
+   * @return The created UnoUrl.
+   */
+  /* default */ static UnoUrl websocket(final String url) {
+    try {
+      return UnoUrl.parseUnoUrl("uno:websocket,url=" + url + ";urp;StarOffice.ServiceManager");
+    } catch (Exception ex) {
+      throw new IllegalArgumentException(ex);
+    }
+  }
+
+  /**
    * Creates an OfficeUrl for the specified pipe.
    *
    * @param pipeName The pipe name.
@@ -122,6 +136,24 @@ class OfficeUrl {
    */
   public OfficeUrl(final @Nullable String host, final int port) {
     unoUrl = socket(host, port);
+  }
+
+  /**
+   * Creates an OfficeUrl for the specified websocket url.
+   *
+   * @param url The websocket url.
+   */
+  /* default */ static OfficeUrl createForWebsocket(final String url) {
+    return new OfficeUrl(websocket(url));
+  }
+
+  /**
+   * Creates an OfficeUrl from a given UnoUrl.
+   *
+   * @param unoUrl The UnoUrl
+   */
+  public OfficeUrl(final @NonNull UnoUrl unoUrl) {
+    this.unoUrl = unoUrl;
   }
 
   /**


### PR DESCRIPTION
a new option alongside "pipe" and "socket" to communicate with a Collabora Online server configured to accept uno over websocket.

urp syntax is:
uno:websocket,url=<url>

in comparison with preexisting
[uno:]socket,host=<hostname>,port=<port>
[uno:]pipe,name=<pipeName>

Implemented in Collabora Online with https://github.com/CollaboraOnline/online/pull/6992 and supported by LibreOffice 24.2 jars with https://gerrit.libreoffice.org/c/core/+/151171

not to be confused with jodconverter's existing "remote" mode which is for collabora-online wrt to the convert-to api connection point. While "external" is the traditional socket mode which this is most similar to.